### PR TITLE
Issue 7

### DIFF
--- a/data_validation/convert_examples.sh
+++ b/data_validation/convert_examples.sh
@@ -23,3 +23,9 @@ linkml-convert -s ../src/mifc/schema/mifc.yaml -C Container -S components test_d
 
 linkml-convert -s ../src/mifc/schema/mifc.yaml -C Container -S components test_data/Component-003.tsv -o results/yaml/Component-003.yaml
 linkml-convert -s ../src/mifc/schema/mifc.yaml -C Container -S components test_data/Component-003.tsv -o results/json/Component-003.json
+
+
+##Provenance
+linkml-convert -s ../src/mifc/schema/mifc.yaml -C Container -S provenances test_data/Provenance-001.tsv -o results/yaml/Provenance-001.yaml
+linkml-convert -s ../src/mifc/schema/mifc.yaml -C Container -S provenances test_data/Provenance-001.tsv -o results/json/Provenance-001.json
+

--- a/data_validation/run_examples.sh
+++ b/data_validation/run_examples.sh
@@ -12,3 +12,6 @@ linkml-validate -s ../src/mifc/schema/mifc.yaml -C Container -S foods test_data/
 linkml-validate -s ../src/mifc/schema/mifc.yaml -C Container -S components test_data/Component-001.tsv
 linkml-validate -s ../src/mifc/schema/mifc.yaml -C Container -S components test_data/Component-002.tsv
 linkml-validate -s ../src/mifc/schema/mifc.yaml -C Container -S components test_data/Component-003.tsv
+
+##Provenance
+linkml-validate -s ../src/mifc/schema/mifc.yaml -C Container -S provenances test_data/Provenance-001.tsv

--- a/data_validation/test_data/Provenance-001.tsv
+++ b/data_validation/test_data/Provenance-001.tsv
@@ -1,2 +1,2 @@
-mifc_version_tag	contributor_orcid	organization_name
-1.0.1	https://orcid.org/0000-0002-3410-4655	USDA
+dataset_label	mifc_version_tag	contributor_orcid	organization_name
+Standard Reference (SR) Legacy	1.0.1	https://orcid.org/0000-0002-3410-4655	USDA

--- a/data_validation/test_data/Provenance-001.tsv
+++ b/data_validation/test_data/Provenance-001.tsv
@@ -1,0 +1,2 @@
+mifc_version_tag	contributor_orcid	organization_name
+1.0.1	https://orcid.org/0000-0002-3410-4655	USDA

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ style = "pep440"
 [tool.poetry.dev-dependencies]
 linkml = "^1.3.5"
 mkdocs-material = "^8.2.8"
-mkdocs-mermaid2-plugin = "^0.6.0"
+mkdocs-mermaid2-plugin = "^1.1.1"
 schemasheets = "^0.1.14"
 
 [build-system]

--- a/src/mifc/schema/mifc.yaml
+++ b/src/mifc/schema/mifc.yaml
@@ -91,6 +91,16 @@ classes:
       - laboratory_conducting_analytical_analysis
       - compound_value_remeasured_for_quality_control
 
+  Provenance:
+    description: >-
+      Supplemental data about the provenance of a Food and Component dataset collection standardized using MIFC.
+    is_a: NamedThing
+    class_uri: schema:Provenance
+    slots:            ## Slots specific to Provenance
+      - mifc_version_tag
+      - contributor_orcid
+      - organization_name
+
   Container:
     tree_root: true
     attributes:
@@ -231,6 +241,14 @@ slots:
     description: A boolean value denoting TRUE if a measured_compound_value was measured more than once for internal laboratory quality control purposes.
     range: boolean
 #    is_a: boolean_slot
+
+  # Provenance slots
+  mifc_version_tag:
+    description: A string corresponding to a named MIFC release number (e.g., "1.0.1").
+  contributor_orcid:
+    description: A string corresponding to a "|" delimited list of ORCIDs of people who contributed to a MIFC formatted dataset. See https://orcid.org/.
+  organization_name:
+    description: A string corresponding to a "|" delimited list of organizations who created or help to create to a MIFC formatted dataset. E.g., "USDA".
 
 
 

--- a/src/mifc/schema/mifc.yaml
+++ b/src/mifc/schema/mifc.yaml
@@ -97,6 +97,7 @@ classes:
     is_a: NamedThing
     class_uri: schema:Provenance
     slots:            ## Slots specific to Provenance
+      - dataset_label
       - mifc_version_tag
       - contributor_orcid
       - organization_name
@@ -247,6 +248,8 @@ slots:
 #    is_a: boolean_slot
 
   # Provenance slots
+  dataset_label:
+    description: A string corresponding to the labeled name of dataset (e.g., "Standard Reference (SR) Legacy").
   mifc_version_tag:
     description: A string corresponding to a named MIFC release number (e.g., "1.0.1").
   contributor_orcid:

--- a/src/mifc/schema/mifc.yaml
+++ b/src/mifc/schema/mifc.yaml
@@ -112,6 +112,10 @@ classes:
         multivalued: true
         inlined_as_list: true
         range: Component
+      provenances:
+        multivalued: true
+        inlined_as_list: true
+        range: Provenance
 
 slots:
   # Common slots


### PR DESCRIPTION
PR addressing #7. Added new Provenance class as a container. I hadn't intended to make this be `multivalued: true` but I couldn't get the tsv to validate without it. Perhaps in a future PR we can do something different for this. 